### PR TITLE
[BUGFIX] Bind to "item:ready" in created() instead of mounted()

### DIFF
--- a/src/BadgerAccordion.vue
+++ b/src/BadgerAccordion.vue
@@ -14,7 +14,7 @@ export default {
             itemsReady: false
         }
     },
-    mounted() {
+    created() {
         // On child-item rendered initiate badger-accordion
         this.$on('item:ready', () => {
             this.accordion = new BadgerAccordion(this.$refs.badger, (this.options || {}))


### PR DESCRIPTION
Fix for https://github.com/vanderb/vue-badger-accordion/issues/1