### PR TITLE
Use semantic definition list markup instead of divs

### DIFF
--- a/src/BadgerAccordion.vue
+++ b/src/BadgerAccordion.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="component-badger-accordion" ref="badger"><slot></slot></div>
+    <dl class="component-badger-accordion" ref="badger"><slot></slot></dl>
 </template>
 
 <script>
@@ -26,7 +26,7 @@ export default {
             default() {return {}}
         },
         icons: {
-            default() {return {opened: '-', closed: '+'} } 
+            default() {return {opened: '-', closed: '+'} }
         }
     },
     data() {

--- a/src/BadgerAccordionItem.vue
+++ b/src/BadgerAccordionItem.vue
@@ -1,20 +1,20 @@
 <template>
     <div class="badger-accordion-item">
-        
-        <div class="badger-accordion__header">
+
+        <dt class="badger-accordion__header">
             <div class="js-badger-accordion-header">
                 <div class="badger-accordion-toggle">
                     <slot name="header">Collapse-Title</slot>
                 </div>
                 <span class="badger-toggle-indicator" v-html="icon"></span>
             </div>
-        </div> 
+        </dt>
 
-        <div class="badger-accordion__panel js-badger-accordion-panel">
+        <dd class="badger-accordion__panel js-badger-accordion-panel">
             <div class="js-badger-accordion-panel-inner">
                 <slot name="content"></slot>
             </div>
-        </div>
+        </dd>
 
     </div>
 </template>
@@ -54,15 +54,15 @@ export default {
 
 	.badger-accordion__panel {
         max-height: 75vh;
-        overflow: hidden; 
-    
-        // scss-lint:disable ImportantRule        
-        &.-ba-is-hidden {            
-            max-height: 0 !important;        
+        overflow: hidden;
+
+        // scss-lint:disable ImportantRule
+        &.-ba-is-hidden {
+            max-height: 0 !important;
         }
-    }    
-    
-    // transition is added via `badger-accordion--initialized` to stop animation on initalition    
+    }
+
+    // transition is added via `badger-accordion--initialized` to stop animation on initalition
     .badger-accordion--initialized {
 
         .badger-accordion__panel {
@@ -80,7 +80,7 @@ export default {
                 flex: 0 0 90%;
                 cursor: pointer;
             }
-            
+
             .badger-toggle-indicator {
                 flex: 0 0 10%;
                 display: flex;


### PR DESCRIPTION
This replaces the `div`s with more semantic `dl`, `dt` and `dd` tags as suggested for accordions.