### PR TITLE
Add .vue extensions to component imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import ImportBadgerAccordion from './src/BadgerAccordion'
-import ImportBadgerAccordionItem from './src/BadgerAccordionItem'
+import ImportBadgerAccordion from './src/BadgerAccordion.vue'
+import ImportBadgerAccordionItem from './src/BadgerAccordionItem.vue'
 
 export const BadgerAccordion = ImportBadgerAccordion;
 export const BadgerAccordionItem = ImportBadgerAccordionItem;


### PR DESCRIPTION
This adds the full Vue components' names to their respective imports, adding compatibility for Vite (and the next Vue CLI version), see https://github.com/vitejs/vite/issues/178.
